### PR TITLE
use underscore in material icon name

### DIFF
--- a/src/app/puppy-love.component.ts
+++ b/src/app/puppy-love.component.ts
@@ -35,7 +35,7 @@ export class PuppyLoveAppComponent {
     {
       name: "My Account",
       description: "Edit my account information",
-      icon: "assignment ind"
+      icon: "assignment_ind"
     },
     {
       name: "Potential dates",


### PR DESCRIPTION
Underscore is needed if the icon name has space in it
